### PR TITLE
Add: regressor ml model, implement train model

### DIFF
--- a/ml_service/ml_models/regressor.py
+++ b/ml_service/ml_models/regressor.py
@@ -2,14 +2,14 @@ import pickle
 from uuid import uuid4
 from fastapi import HTTPException
 import pandas as pd
-from sklearn.ensemble import RandomForestRegressor
+from sklearn.ensemble import RandomForestRegressor as SklearnRandomForestRegressor
 from pydantic import BaseModel, Field
 import tempfile
 
 from ml_service.schemas.regressor import TrainModelResponse
 
 
-class RandomForestModel(BaseModel):
+class RandomForestRegressor(BaseModel):
     target: str = Field(..., description="Target column name")
     n_estimators: int = Field(..., description="Number of estimators for the model")
     max_depth: int | None = Field(
@@ -41,12 +41,12 @@ class RandomForestModel(BaseModel):
                 status_code=400, detail=f"Target column '{self.target}' not found"
             )
 
-    def _save_model_locally(self, model: RandomForestRegressor) -> str:
+    def _save_model_locally(self, model: SklearnRandomForestRegressor) -> str:
         """
         Save the given Random Forest Regressor model locally.
 
         Parameters:
-            model (RandomForestRegressor): The model to be saved.
+            model (SklearnRandomForestRegressor): The model to be saved.
 
         Returns:
             str: The file path where the model is saved.
@@ -69,7 +69,7 @@ class RandomForestModel(BaseModel):
         Raises:
             HTTPException: If the `train_data` does not have column names or if the target column is not found for training.
         """
-        model = RandomForestRegressor(
+        model = SklearnRandomForestRegressor(
             n_estimators=self.n_estimators,
             max_depth=self.max_depth,
             random_state=self.random_state,

--- a/ml_service/ml_models/regressor.py
+++ b/ml_service/ml_models/regressor.py
@@ -1,0 +1,98 @@
+import pickle
+from uuid import uuid4
+from fastapi import HTTPException
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from pydantic import BaseModel, Field
+from sklearn.model_selection import train_test_split
+
+from ml_service.schemas.regressor import SaveModel, TrainModel
+
+
+class Regressor(BaseModel):
+    target: str = Field(..., description="Target column name")
+    n_estimators: int = Field(..., description="Number of estimators for the model")
+    max_depth: int | None = Field(
+        default=None, description="Maximum depth for the model"
+    )
+    random_state: int = Field(..., description="Random state for the model")
+
+    def _validate_data(self, data: pd.DataFrame, is_train: bool = True) -> None:
+        """
+        Validates the given DataFrame `data` for training or inference.
+
+        Args:
+            data (pd.DataFrame): The DataFrame to be validated.
+            is_train (bool, optional): Flag indicating whether the data is for training. Defaults to True.
+
+        Raises:
+            HTTPException: If the DataFrame does not have column names or if the target column is not found for training.
+
+        Returns:
+            None
+        """
+        if data.columns.isnull().any():
+            raise HTTPException(
+                status_code=400, detail="Dataset must have column names"
+            )
+
+        if is_train and self.target not in data.columns:
+            raise HTTPException(
+                status_code=400, detail=f"Target column '{self.target}' not found"
+            )
+
+    def _save_model(self, model: RandomForestRegressor) -> SaveModel:
+        """
+        Saves the given RandomForestRegressor model to a pickle file in the specified directory.
+
+        Args:
+            model (RandomForestRegressor): The model to be saved.
+
+        Returns:
+            str: The path of the saved pickle file.
+        """
+        model_id: str = str(uuid4())
+        save_path: str = f"/home/luna/tamadevu/ml_service_models/{model_id}.pkl"
+        with open(save_path, "wb") as f:
+            pickle.dump(model, f)
+
+        return SaveModel(save_path=save_path, model_id=model_id)
+
+    def train(self, train_data: pd.DataFrame, test_split: float = 0.2) -> TrainModel:
+        """
+        Trains a random forest regressor model on the given `train_data` and saves the model to a pickle file.
+
+        Args:
+            train_data (pd.DataFrame): The training data to be used for training the model.
+            test_split (float, optional): The proportion of the dataset to include in the test split. Defaults to 0.2.
+
+        Returns:
+            TrainModel: An instance of the `TrainModel` class containing the save path, model ID, and score of the trained model.
+
+        Raises:
+            HTTPException: If the `train_data` does not have column names or if the target column is not found for training.
+        """
+        model = RandomForestRegressor(
+            n_estimators=self.n_estimators,
+            max_depth=self.max_depth,
+            random_state=self.random_state,
+        )
+
+        self._validate_data(train_data)
+        X: pd.DataFrame = train_data.drop(columns=[self.target])
+        y: pd.Series = train_data[self.target]
+
+        X_train, X_val, y_train, y_val = train_test_split(
+            X, y, test_size=test_split, random_state=self.random_state
+        )
+
+        model.fit(X_train, y_train)
+        save_results: SaveModel = self._save_model(model)
+
+        score: float = float(model.score(X_val, y_val))
+
+        return TrainModel(
+            save_path=save_results.save_path,
+            model_id=save_results.model_id,
+            score=score,
+        )

--- a/ml_service/schemas/regressor.py
+++ b/ml_service/schemas/regressor.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class SaveModel(BaseModel):
+    save_path: str
+    model_id: str
+
+
+class TrainModel(SaveModel):
+    score: float

--- a/ml_service/schemas/regressor.py
+++ b/ml_service/schemas/regressor.py
@@ -1,10 +1,6 @@
 from pydantic import BaseModel
 
 
-class SaveModel(BaseModel):
+class TrainModelResponse(BaseModel):
     save_path: str
     model_id: str
-
-
-class TrainModel(SaveModel):
-    score: float

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -1,0 +1,68 @@
+import pytest
+import pandas as pd
+from fastapi import HTTPException
+from sklearn.ensemble import RandomForestRegressor
+from ml_service.ml_models.regressor import Regressor
+from ml_service.schemas.regressor import SaveModel, TrainModel
+from unittest.mock import mock_open, patch
+
+
+@pytest.fixture
+def regressor():
+    return Regressor(target="target", n_estimators=10, max_depth=5, random_state=42)
+
+
+@pytest.fixture
+def valid_data():
+    return pd.DataFrame(
+        {"feature_1": [1, 2, 3], "feature_2": [4, 5, 6], "target": [7, 8, 9]},
+        index=None,
+    )
+
+
+@pytest.fixture
+def invalid_data_no_columns():
+    return pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=[None, None, None])
+
+
+def test_validate_data_no_columns(regressor, invalid_data_no_columns):
+    with pytest.raises(HTTPException) as excinfo:
+        regressor._validate_data(invalid_data_no_columns)
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "Dataset must have column names"
+
+
+def test_validate_data_valid(regressor, valid_data):
+    try:
+        regressor._validate_data(valid_data)
+    except HTTPException:
+        pytest.fail("Unexpected HTTPException raised")
+
+
+@patch("builtins.open", new_callable=mock_open)
+@patch("pickle.dump")
+def test_save_model(mock_pickle_dump, mock_open_file, regressor):
+    model = RandomForestRegressor()
+    result = regressor._save_model(model)
+    assert isinstance(result, SaveModel)
+    assert mock_open_file.called
+    assert mock_pickle_dump.called
+
+
+@patch.object(
+    Regressor,
+    "_save_model",
+    return_value=SaveModel(save_path="path/to/model.pkl", model_id="12345"),
+)
+@patch("ml_service.ml_models.regressor.RandomForestRegressor.fit")
+@patch("ml_service.ml_models.regressor.RandomForestRegressor.score")
+def test_train_model(mock_save_model, mock_score, mock_fit, regressor, valid_data):
+    result = regressor.train(valid_data)
+    assert isinstance(result, TrainModel)
+    assert mock_fit.called
+    assert mock_save_model.called
+    assert mock_score.called
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -1,15 +1,15 @@
 import pytest
 import pandas as pd
 from fastapi import HTTPException
-from sklearn.ensemble import RandomForestRegressor
-from ml_service.ml_models.regressor import RandomForestModel
+from sklearn.ensemble import RandomForestRegressor as SklearnRandomForestRegressor
+from ml_service.ml_models.regressor import RandomForestRegressor
 from ml_service.schemas.regressor import TrainModelResponse
 from unittest.mock import patch
 
 
 @pytest.fixture
 def regressor():
-    return RandomForestModel(
+    return RandomForestRegressor(
         target="target", n_estimators=10, max_depth=5, random_state=42
     )
 
@@ -43,18 +43,18 @@ def test_validate_data_valid(regressor, valid_data):
 
 @patch("pickle.dump")
 def test_save_model(mock_pickle_dump, regressor):
-    model = RandomForestRegressor()
+    model = SklearnRandomForestRegressor()
     result = regressor._save_model_locally(model)
     assert isinstance(result, str)
     assert mock_pickle_dump.called
 
 
 @patch.object(
-    RandomForestModel,
+    RandomForestRegressor,
     "_save_model_locally",
     return_value="path/to/model.pkl",
 )
-@patch("ml_service.ml_models.regressor.RandomForestRegressor.fit")
+@patch("ml_service.ml_models.regressor.SklearnRandomForestRegressor.fit")
 def test_train_model(mock_save_model, mock_fit, regressor, valid_data):
     result = regressor.train(valid_data)
     assert isinstance(result, TrainModelResponse)


### PR DESCRIPTION
This PR implements regressor model which is the model that will be called by `/train` api in the future. At the moment it just has train functionality.

The regressor model includes:
- implementation of a train function that trains the model
-  saves it locally, and
- returns the model path, model id, and its score on validation data.

## Other changes:
- tests for regressor class