### PR TITLE
Add: test method to regressor model

### DIFF
--- a/ml_service/schemas/regressor.py
+++ b/ml_service/schemas/regressor.py
@@ -1,6 +1,16 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TrainModelResponse(BaseModel):
     save_path: str
     model_id: str
+
+
+class PerformanceMetrics(BaseModel):
+    mse: float = Field(description="Mean Squared Error")
+    rmse: float = Field(description="Root Mean Squared Error")
+    r2: float = Field(description="R-squared")
+
+
+class TestModelResponse(PerformanceMetrics):
+    deployable: bool = Field(description="Is model deployable?")


### PR DESCRIPTION
This PR implements test method for regressor model.
**Input**:  `model_id`, `test_csv`
**Output**:  `TestModelRespones(performance metrics, is_deployable)`

Other changes:
- changes the `save_file_locally `function to not delete the created temp file where the model is stored locally.
- tests for test method in RandomForestRegressor class
